### PR TITLE
Removed fill color from transparent area in AcademicCapOutline

### DIFF
--- a/src/icons/AcademicCapOutline.tsx
+++ b/src/icons/AcademicCapOutline.tsx
@@ -17,9 +17,9 @@ const AcademicCapOutline = (
       ref={svgRef}
       {...props}
     >
-      <path fill="#fff" d="M12 14l9-5-9-5-9 5 9 5z" />
+      <path fill="none" d="M12 14l9-5-9-5-9 5 9 5z" />
       <path
-        fill="#fff"
+        fill="none"
         d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z"
       />
       <path


### PR DESCRIPTION
The `AcademicCapOutline` icon has areas that symbolize the transparent area in the icon. This library wrongfully gives these areas a fill color, that is not present in the svg normally.

**Currently**
![Academic Cap Outline Filled Background](https://user-images.githubusercontent.com/15874697/90458436-b1f28f00-e0fe-11ea-920f-db5855e97113.png)

**After Fix**
![Academic Cap Outline Transparent Background](https://user-images.githubusercontent.com/15874697/90458486-d5b5d500-e0fe-11ea-8b41-4ede6f9bd5e6.png)
